### PR TITLE
Fix urls

### DIFF
--- a/build-properties.xml
+++ b/build-properties.xml
@@ -5,14 +5,14 @@
   <toDir>swinburne-static-out</toDir>
   <!-- This directory inside dhq-static will hold the static site's individual files
     (but not the compressed site). -->
-  <context>/</context>
+  <context></context>
   
   <!-- The directory in which HTML articles are saved for previewing. Note that if 
     you change this value, you may also have to change the "assets-path" parameter 
     value in build.xml's "previewArticle" target, and/or add a new value to the 
     repository .gitignore file. -->
   <previewDir>swinburne-static-preview</previewDir>
-  <server>swinburne.luddy.indiana.edu</server>
+  <server></server>
   
   <!-- The XSLT processor to use. -->
   <processor>

--- a/build.xml
+++ b/build.xml
@@ -16,7 +16,7 @@
   <property name="toDir.base" value="..${file.separator}${toDir}"/>
   <property name="dummy.input" value="common/xslt/dummy.xml"/>
   <!-- Within ${toDir.base}, individually generated static site files will be 
-    written to the ${context} directory. -->
+  written to the ${context} directory. -->
   <property name="toDir.static" value="${toDir.base}${file.separator}${context}"/>
   <property name="toDir.tmpHTML" value="${toDir.base}${file.separator}tmpHTML"/>
   <property name="toDir.tmpTEI" value="${toDir.base}${file.separator}tmpTEI"/>
@@ -106,6 +106,7 @@ is loaded when Ant starts up. Please run Ant again like this:
         <attribute name="http://saxon.sf.net/feature/xinclude-aware" value="on"/>
       </factory>
       <param name="server" expression="${server}"/>
+      <param name="context" expression="${context}"/>
     </xslt>
   </target>
   <target name="processContents">
@@ -120,6 +121,7 @@ is loaded when Ant starts up. Please run Ant again like this:
         <attribute name="http://saxon.sf.net/feature/initialTemplate" value="{http://www.w3.org/1999/XSL/Transform}initial-template"/>
       </factory>
       <param name="server" expression="${server}"/>
+      <param name="context" expression="${context}"/>
       <!--
       <param name="assets-path" expression="..${file.separator}"/>
       <param name="context" expression="swinburne"/>
@@ -175,9 +177,9 @@ is loaded when Ant starts up. Please run Ant again like this:
       </xmlcatalog>
       <factory name="${processor.name}"/>
       <param name="assets-path" expression="..${file.separator}"/>
-      <param name="context" expression="${context}"/>
       <param name="authority.uri" expression="file:${authority.expanded.file}"/>
       <param name="server" expression="${server}"/>
+      <param name="context" expression="${context}"/>
     </xslt>
   </target>
   <!-- Generate a static version of the Swinburne Project website. -->
@@ -284,10 +286,10 @@ is loaded when Ant starts up. Please run Ant again like this:
     <xslt in="articles${file.separator}${document.id}${file.separator}${document.id}.xml" out="${previewDir}${file.separator}${document.id}.html" style="common${file.separator}xslt${file.separator}template_article.xsl" classpath="${processor.location}" force="true" failOnTransformationError="false">
       <factory name="${processor.name}"/>
       <param name="assets-path" expression="${assets.path}"/>
-      <param name="context" expression="${context}"/>
       <param name="dir-separator" expression="${file.separator}"/>
       <param name="doProofing" expression="true"/>
       <param name="server" expression="${server}"/>
+      <param name="context" expression="${context}"/>
     </xslt>
     <echo message="Created article preview at ${previewDir}${file.separator}${document.id}.html"/>
   </target>

--- a/common/xslt/add-site-navigation.xsl
+++ b/common/xslt/add-site-navigation.xsl
@@ -6,6 +6,7 @@
   xmlns="http://www.w3.org/1999/xhtml" 
   xmlns:map="http://www.w3.org/2005/xpath-functions/map"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:swinburne="tag:biblicon.org,2024:swinburne"
   version="3.0" 
   xpath-default-namespace="http://www.w3.org/1999/xhtml" 
   exclude-result-prefixes="fn map tei xs" 
@@ -31,6 +32,9 @@
     then $authority.uri
     else concat('file:', $authority.uri)
     )"/>
+  
+  <xsl:variable name="ctx" as="xs:string"
+    select="replace(replace(replace(normalize-space($context), '''', ''), '^/+', ''), '/+$', '')"/>
   <xsl:mode on-no-match="shallow-copy"/>
   <!-- insert link to global CSS, any global <meta> elements belong here too -->
   <xsl:template match="head">
@@ -71,16 +75,7 @@
         <nav id="main-nav" class="navbar navbar-expand-md navbar-dark bg-dark">
           <div class="container-fluid">
             <a class="navbar-brand">
-              <xsl:attribute name="href">
-                <xsl:choose>
-                  <xsl:when test="$context != '/'">
-                    <xsl:value-of select="concat('/',$context,'/')"/>
-                  </xsl:when>
-                  <xsl:otherwise>
-                    <xsl:value-of select="'/'"/>
-                  </xsl:otherwise>
-                </xsl:choose>
-              </xsl:attribute>
+              <xsl:attribute name="href" select="swinburne:site-path('')"/>
               <xsl:text>ACS</xsl:text>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
@@ -163,16 +158,9 @@
     <xsl:if test="not($search-page = 'true' and @key = 'Search &#x1F50E;')">
       <li class="nav-item">
         <a class="nav-link">
-          <xsl:attribute name="href">
-            <xsl:choose>
-              <xsl:when test="$context != '/'">
-                <xsl:value-of select="concat('/',$context,.)"/>
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:value-of select="."/>
-              </xsl:otherwise>
-            </xsl:choose>
-          </xsl:attribute>
+          <xsl:attribute name="href"
+            select="if (starts-with(., 'http')) then .
+            else concat('/', swinburne:site-path(replace(., '^/+', '')))"/>
           <xsl:value-of select="@key"/>
         </a>
       </li>
@@ -180,23 +168,9 @@
   </xsl:template>
   <xsl:template match="fn:map[ancestor::fn:map]/fn:string" mode="main-menu">
     <a class="dropdown-item">
-      <xsl:attribute name="href">
-        <xsl:choose>
-          <xsl:when test="starts-with(.,'http')">
-            <xsl:value-of select="."/>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:choose>
-              <xsl:when test="$context != '/'">
-                <xsl:value-of select="concat('/',$context,.)"/>
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:value-of select="."/>
-              </xsl:otherwise>
-            </xsl:choose>
-          </xsl:otherwise>
-        </xsl:choose>
-      </xsl:attribute>
+      <xsl:attribute name="href"
+        select="if (starts-with(., 'http')) then .
+        else concat('/', swinburne:site-path(replace(., '^/+', '')))"/>
       <xsl:value-of select="@key"/>
     </a>
   </xsl:template>
@@ -582,12 +556,37 @@ Code repository: <a href="https://github.com/jawalsh/swinburne">jawalsh/swinburn
   </xsl:template>
   <xsl:template name="generateURL">
     <xsl:param name="docID"/>
-    <xsl:value-of select="concat('https://',$server,'/',$site-dir,'/',$docID,'.html')"/>
+    
+    <xsl:variable name="ctx"
+      select="replace(replace(replace(normalize-space($context), '''', ''), '^/+', ''), '/+$', '')"/>
+    
+    <xsl:variable name="path"
+      select="if ($ctx = '' or $ctx = '/') 
+      then concat($docID, '.html') 
+      else concat($ctx, '/', $docID, '.html')"/>
+    
+    <xsl:value-of
+      select="if (normalize-space($server) = '') 
+      then $path 
+      else concat('https://', $server, '/', $path)"/>
   </xsl:template>
+  
   <xsl:template name="generateInternalURL">
     <xsl:param name="docID"/>
     <xsl:param name="ref"/>
-    <xsl:value-of select="concat('https://',$server,'/',$site-dir,'/',$docID,'.html#',$ref)"/>
+    
+    <xsl:variable name="ctx"
+      select="replace(replace(replace(normalize-space($context), '''', ''), '^/+', ''), '/+$', '')"/>
+    
+    <xsl:variable name="path"
+      select="if ($ctx = '' or $ctx = '/') 
+      then concat($docID, '.html') 
+      else concat($ctx, '/', $docID, '.html')"/>
+    
+    <xsl:value-of
+      select="if (normalize-space($server) = '') 
+      then concat($path, '#', $ref) 
+      else concat('https://', $server, '/', $path, '#', $ref)"/>
   </xsl:template>
   <!-- notes -->
   <xsl:template match="div[contains-token(@class, 'tei-note') and (@id) and not(contains-token(@class,'rendition-rester-en-place'))]">

--- a/common/xslt/config.xsl
+++ b/common/xslt/config.xsl
@@ -1,15 +1,44 @@
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" 
-        xmlns:fn="http://www.w3.org/2005/xpath-functions" 
-        xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns="http://www.w3.org/1999/xhtml" 
-	xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-	xpath-default-namespace="http://www.w3.org/1999/xhtml"
-	exclude-result-prefixes="fn map"
-	 expand-text="true">
-	<!-- embed the page in global navigation -->
-	<xsl:param name="current-uri"/>
-        <xsl:param name="google-api-key" select="'AIzaSyBgfj-W6-mYky-0UnIHhhE1yfRt7P85o5I'"/>
-        <xsl:param name="server" select="'swinburne.luddy.indiana.edu'"/>
-        <xsl:param name="site-dir" select="''"/>
-	<xsl:param name="numberFigures" as="xs:boolean" select="true()"/>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:swinburne="tag:biblicon.org,2024:swinburne" 
+  xmlns="http://www.w3.org/1999/xhtml" xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+  xpath-default-namespace="http://www.w3.org/1999/xhtml" exclude-result-prefixes="fn map"
+  expand-text="true">
+  <!-- embed the page in global navigation -->
+  <xsl:param name="current-uri"/>
+  <xsl:param name="google-api-key" select="'AIzaSyBgfj-W6-mYky-0UnIHhhE1yfRt7P85o5I'"/>
+  <xsl:param name="numberFigures" as="xs:boolean" select="true()"/>
+
+  <xsl:param name="server" select="''"/>
+  <xsl:param name="context" select="''"/>
+
+  <!-- normalize context to '' or 'swinburne' (no leading/trailing slashes) -->
+  <xsl:variable name="context-norm" as="xs:string"
+    select="replace(replace(normalize-space($context), '^/+', ''), '/+$', '')"/>
+
+  <!-- site-path: prefix a site-relative path with context (NO leading slash) -->
+  <xsl:function name="swinburne:site-path" as="xs:string">
+    <xsl:param name="p" as="xs:string"/>
+    <xsl:variable name="p2" select="replace($p, '^/+', '')"/>
+    <xsl:sequence select="
+        if ($context-norm = '') then
+          $p2
+        else
+          if ($p2 = '') then
+            concat($context-norm, '/')
+          else
+            concat($context-norm, '/', $p2)
+        "/>
+  </xsl:function>
+
+  <!-- absolute-url: https://server/{context}/{path} when server is set; else site-path -->
+  <xsl:function name="swinburne:absolute-url" as="xs:string">
+    <xsl:param name="p" as="xs:string"/>
+    <xsl:sequence select="
+        if (normalize-space($server) = '') then
+          swinburne:site-path($p)
+        else
+          concat('https://', $server, '/', swinburne:site-path($p))
+        "/>
+  </xsl:function>
 </xsl:stylesheet>

--- a/common/xslt/contents-json-html.xsl
+++ b/common/xslt/contents-json-html.xsl
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<xsl:stylesheet xmlns="http://www.w3.org/1999/xhtml" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:fn="http://www.w3.org/2005/xpath-functions" exclude-result-prefixes="fn" version="3.0">
+<xsl:stylesheet xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:swinburne="tag:biblicon.org,2024:swinburne"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions" exclude-result-prefixes="fn" version="3.0">
   <xsl:import href="config.xsl"/>
   <xsl:output method="xhtml" indent="yes"/>
   <!-- Initial Template -->
@@ -203,29 +206,14 @@
 
   </xsl:template>
 
-
   <xsl:template name="generateURL">
     <xsl:param name="docID"/>
-    <xsl:choose>
-	    <xsl:when test="$site-dir = ''">
-    <xsl:value-of select="concat('https://',$server,'/',$docID,'.html')"/>
-	    </xsl:when>
-	    <xsl:otherwise>
-    <xsl:value-of select="concat('https://',$server,'/',$site-dir,'/',$docID,'.html')"/>
-    </xsl:otherwise>
-    </xsl:choose>
-
+    <xsl:value-of select="concat('/', swinburne:site-path(concat($docID, '.html')))"/>
   </xsl:template>
+  
   <xsl:template name="generateInternalURL">
     <xsl:param name="docID"/>
     <xsl:param name="ref"/>
-    <xsl:choose>
-	    <xsl:when test="$site-dir = ''">
-    <xsl:value-of select="concat('https://',$server,'/',$docID,'.html#',$ref)"/>
-	    </xsl:when>
-	    <xsl:otherwise>
-    <xsl:value-of select="concat('https://',$server,'/',$site-dir,'/',$docID,'.html#',$ref)"/>
-    </xsl:otherwise>
-    </xsl:choose>
+    <xsl:value-of select="concat('/', swinburne:site-path(concat($docID, '.html')), '#', $ref)"/>
   </xsl:template>
 </xsl:stylesheet>

--- a/common/xslt/p5-to-html.xsl
+++ b/common/xslt/p5-to-html.xsl
@@ -48,8 +48,8 @@
         <title>
           <xsl:value-of select="$title"/>
         </title>
-        <link href="/css/tei.css" rel="stylesheet" type="text/css"/>
-        <link href="/css/highlighting.css" rel="stylesheet" type="text/css"/>
+        <link href="{swinburne:site-path('css/tei.css')}" rel="stylesheet" type="text/css"/>
+        <link href="{swinburne:site-path('css/highlighting.css')}" rel="stylesheet" type="text/css"/>
         <!-- no manifest for swinburne -->
         <!--				<link href="{$embedded-manifest-uri}" rel="alternate" type="application/ld+json" title="iiif-manifest"/> -->
         <!-- output the rendition elements as CSS rules -->
@@ -199,14 +199,7 @@
   <xsl:variable name="introduction" select="/TEI/teiHeader/fileDesc/sourceDesc/msDesc/msContents/msItem/note[@type = 'introduction']"/>
   <xsl:template match="teiHeader">
     <xsl:param name="html-link">
-      <xsl:choose>
-        <xsl:when test="$site-dir = '/'">
-          <xsl:value-of select="concat('https://',$server,'/',$doc-id,'.html')"/>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="concat('https://', $server, '/', $site-dir, '/', $doc-id, '.html')"/>
-        </xsl:otherwise>
-      </xsl:choose>
+      <xsl:value-of select="swinburne:absolute-url(concat($doc-id, '.html'))"/>
     </xsl:param>
     <div id="doc-meta">
       <div class="tei-teiHeader">
@@ -535,7 +528,7 @@
     <xsl:attribute name="title">
       <xsl:apply-templates mode="citation-popup" select="serialize($formatted-citation)"/>
     </xsl:attribute>
-    <xsl:attribute name="href" select="concat('/bibliography#', $id)"/>
+    <xsl:attribute name="href" select="concat(swinburne:site-path('bibliography'), '#', $id)"/>
     <xsl:next-match/>
   </xsl:template>
   <!-- bibliographic citation popups -->
@@ -548,7 +541,7 @@
         <xsl:apply-templates mode="citation-popup" select="monogr/imprint"/>
       </p>
       <p>
-        <a href="/bibliography#{@xml:id}">[View Full Citation]</a>
+        <a href="{concat(swinburne:site-path('bibliography'), '#', @xml:id)}">[View Full Citation]</a>
         <xsl:for-each select="monogr/title/@ref">
           <xsl:text> </xsl:text>
           <a href="{.}">[View Full Text]</a>


### PR DESCRIPTION
This PR reduces hard-coded URL and deployment assumptions across the build and generated site. It replaces fixed host/context/path values with configurable properties, and updates generation steps to produce consistent links across environments (local, staging, production). Net effect: fewer broken links and easier site moves without patching source.